### PR TITLE
Strict define the import rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 /public/build
+/api

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "@remix-run/eslint-config/node",
     "prettier"
   ],
+  "plugins": ["strict-dependencies"],
   "rules": {
     "import/order": [
       "error",
@@ -28,6 +29,21 @@
           "caseInsensitive": true
         }
       }
+    ],
+    "strict-dependencies/strict-dependencies": [
+      "error",
+      [
+        {
+          "module": "firebase",
+          "allowReferenceFrom": ["app/services/api"],
+          "allowSameModule": false
+        },
+        {
+          "module": "app/services/api",
+          "allowReferenceFrom": ["app/services"],
+          "allowSameModule": true
+        }
+      ]
     ]
   },
   "settings": {

--- a/app/App.server.ts
+++ b/app/App.server.ts
@@ -1,6 +1,5 @@
 import type { MetaFunction } from '@remix-run/node';
-import { authToServer } from './services/api/auth/auth';
-import { initApiConnection } from './services/auth';
+import { authToServer, initApiConnection } from './services/auth';
 
 // Init API connection with server
 initApiConnection();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/styled-components": "^5.1.24",
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-strict-dependencies": "^1.0.1",
     "prettier": "^2.6.2",
     "typescript": "^4.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2929,6 +2929,15 @@ eslint-plugin-react@^7.28.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
+eslint-plugin-strict-dependencies@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-strict-dependencies/-/eslint-plugin-strict-dependencies-1.0.1.tgz#5c3d1a72c565f1965b3a6a94d001838658eaa637"
+  integrity sha512-KV5g9HfcB2nCYZ9fk+6Jyh9R20McnTdRtCjPve32FTk8fcjPvR+qwBmp2Z47UtXP/rPB7aEsM5GsuFWiAtV81Q==
+  dependencies:
+    is-glob "^4.0.3"
+    micromatch "^4.0.4"
+    require-strip-json-comments "^2.0.0"
+
 eslint-plugin-testing-library@^5.0.5:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.5.0.tgz#ce43113dac5a5d93e8b0a8d9937983cdbf63f049"
@@ -6051,6 +6060,13 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-strip-json-comments@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-strip-json-comments/-/require-strip-json-comments-2.0.0.tgz#71733597bdd5c8581e1c01af485e3540ddc1f5a4"
+  integrity sha512-Pta3KVBaVZ9DHMoOGRd+3PEc/EFZAQ1JVHQpKZfPo018fdT9iEsyPBzqNAgJAzKMF4kbr5G7GaqP0+UOwnGfPw==
+  dependencies:
+    strip-json-comments "^3.0"
+
 requireindex@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
@@ -6613,7 +6629,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.0, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==


### PR DESCRIPTION
# Why
- add [eslint-plugin-strict-dependencies](https://github.com/knowledge-work/eslint-plugin-strict-dependencies) to restrict the import rules

# Summary
- In the current structure, the `services/api/*` files are only allowed used by the actions in the service. It CAN NOT and SHOULD NOT be used directly by the component side (The main reason is for abstracting the API accessing flow)
- As the above reason, the `firebase` related libraries should not be used directly on the component side as well. In the future, we might replace the firebase with other services

# Testing
- [ ] check whether the incorrect import routes will cause errors or not (which it SHOULD)

# Related Links
- [Related design files, referencing sources, etc.](https://github.com/knowledge-work/eslint-plugin-strict-dependencies)

# Screenshots
<img width="842" alt="CleanShot 0004-05-25 at 17 11 19@2x" src="https://user-images.githubusercontent.com/44968790/170214097-072489a1-dee9-4c3f-9be7-e10745c3f3f8.png">
